### PR TITLE
feat: refresh website i18n and ui

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,17 +1,25 @@
 main:
   - title: "Home"
+    i18n_key: nav.home
     url: /
   - title: "Quick Start"
+    i18n_key: nav.quick_start
     url: /quick-start/
   - title: "Learn"
+    i18n_key: nav.learn
     url: /learn/
   - title: "Research"
+    i18n_key: nav.research
     url: /research/
   - title: "Projects"
+    i18n_key: nav.projects
     url: /projects/
   - title: "Docs"
+    i18n_key: nav.docs
     url: /docs/
   - title: "App"
+    i18n_key: nav.app
     url: /app/
   - title: "About Me"
+    i18n_key: nav.about
     url: /about-me/

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -5,6 +5,20 @@
 <meta name="apple-mobile-web-app-title" content="BagelQuant" />
 <link rel="manifest" href="/site.webmanifest" />
 
+<script>
+	(function() {
+		try {
+			var language = localStorage.getItem('bagelquant.language');
+			if (language === 'zh') {
+				document.documentElement.lang = 'zh-CN';
+				document.documentElement.dataset.lang = 'zh';
+			}
+			var theme = localStorage.getItem('theme');
+			if (theme === 'dark') document.documentElement.classList.add('dark');
+		} catch (e) {}
+	})();
+</script>
+
 <link
 	rel="stylesheet"
 	href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,7 +2,7 @@
   {% assign nav_items = site.data.navigation.main %}
   {% if nav_items %}
     <div class="nav-controls">
-      <button id="theme-toggle" class="nav-link nav-link-theme" aria-label="Toggle dark mode" aria-pressed="false" title="Toggle theme" type="button">
+      <button id="theme-toggle" class="nav-link nav-link-theme" aria-label="Toggle dark mode" aria-pressed="false" title="Toggle theme" type="button" data-i18n-aria-label="nav.theme_label" data-i18n-title="nav.theme_label">
         <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
         </svg>
@@ -19,7 +19,13 @@
         </svg>
       </button>
 
-      <a href="{{ "/search/" | relative_url }}" class="nav-link nav-link-search" aria-label="Search site">
+      <button id="language-toggle" class="nav-link nav-link-language" aria-label="Switch language" aria-pressed="false" title="Switch language" type="button" data-i18n-aria-label="nav.lang_label" data-i18n-title="nav.lang_label">
+        <span class="language-option is-active" data-lang-option="en">EN</span>
+        <span class="language-divider" aria-hidden="true">/</span>
+        <span class="language-option" data-lang-option="zh">中</span>
+      </button>
+
+      <a href="{{ "/search/" | relative_url }}" class="nav-link nav-link-search" aria-label="Search site" data-i18n-aria-label="nav.search_label">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <path d="M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
           <path d="M21 21l-4.35-4.35" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -32,7 +38,7 @@
         {% assign item_url = item.url | relative_url %}
         <li class="nav-item">
           <a href="{{ item_url }}" class="nav-link">
-            <span class="nav-title">{{ item.title }}</span>
+            <span class="nav-title"{% if item.i18n_key %} data-i18n="{{ item.i18n_key }}"{% endif %}>{{ item.title }}</span>
           </a>
         </li>
       {% endfor %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,225 +1,25 @@
-<script type="text/javascript" async
-    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML">
-</script>
-
 <script>
-  // Small-screen toggle for generic left sidebars (page + post)
-  (function() {
-    document.addEventListener('DOMContentLoaded', function() {
-      var mq = window.matchMedia('(max-width: 960px)');
-      var initialized = false;
-
-      function setupToggle() {
-        if (!mq.matches || initialized) return;
-        initialized = true;
-
-        var pageSidebar = document.querySelector('.page-sidebar');
-        var postSidebar = document.querySelector('.post-sidebar-left');
-
-        // Prefer a page sidebar if present; otherwise use post sidebar
-        var sidebar = pageSidebar || postSidebar;
-        if (!sidebar) return;
-
-        // Insert toggle button above the whole three-column layout
-        var layout = document.querySelector('.layout-three-column');
-        if (!layout || layout.parentNode.querySelector('.sidebar-toggle')) return;
-
-        var btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'sidebar-toggle';
-        btn.setAttribute('aria-label', 'Toggle navigation');
-        // Use a small SVG menu icon that inherits color (currentColor)
-        // so it adapts automatically to light/dark themes and stays sized.
-        btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">'
-          + '<path d="M3 6h18" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>'
-          + '<path d="M3 12h18" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>'
-          + '<path d="M3 18h18" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>'
-          + '</svg>';
-        btn.addEventListener('click', function() {
-          sidebar.classList.toggle('is-open');
-        });
-
-        layout.parentNode.insertBefore(btn, layout);
-      }
-
-      setupToggle();
-      mq.addEventListener('change', function(e) {
-        if (e.matches) setupToggle();
-      });
-    });
-  })();
+  window.BagelQuantPage = {
+    toc: {{ page.toc | default: true | jsonify }}
+  };
 </script>
 
 <script type="text/x-mathjax-config">
-   MathJax.Hub.Config({
-     extensions: ["tex2jax.js"],
-     jax: ["input/TeX", "output/HTML-CSS"],
-     tex2jax: {
-       inlineMath: [ ['$','$'], ["\\(","\\)"] ],
-       displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
-       processEscapes: true
-     },
-     "HTML-CSS": { availableFonts: ["TeX"] }
-   });
+  MathJax.Hub.Config({
+    extensions: ["tex2jax.js"],
+    jax: ["input/TeX", "output/HTML-CSS"],
+    tex2jax: {
+      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+      displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+      processEscapes: true
+    },
+    "HTML-CSS": { availableFonts: ["TeX"] }
+  });
 </script>
 
-<script>
-  (function() {
-    document.addEventListener('DOMContentLoaded', function() {
-      // Only build TOC for numbered post/page content
-      var content = document.querySelector('.post-content.numbered');
-      if (!content) return;
-
-      // Allow disabling via `toc: false` in front matter
-      if (!{{ page.toc | default: true | jsonify }}) return;
-
-      var headings = content.querySelectorAll('h2, h3');
-      if (!headings.length) return;
-
-      // Decide which TOC container to use: post or page
-      var tocContainer = document.querySelector('.post-toc .toc-inner') ||
-                         document.querySelector('.page-toc .toc-inner');
-      if (!tocContainer) return;
-
-      // Build TOC header and list (toggle button lives in header)
-      tocContainer.innerHTML = '';
-
-      var headingEl = document.createElement('h2');
-      headingEl.textContent = 'In this article';
-
-      var ul = document.createElement('ul');
-
-      var h2Count = 0, h3Count = 0;
-
-      headings.forEach(function(h) {
-        if (!h.id) {
-          h.id = h.textContent.trim().toLowerCase()
-            .replace(/[^\w\- ]+/g, '')
-            .replace(/\s+/g, '-');
-        }
-
-        var li = document.createElement('li');
-        li.className = 'toc-level-' + h.tagName.toLowerCase();
-
-        var a = document.createElement('a');
-        a.href = '#' + h.id;
-
-        // Compute numbering that matches the in-content numbering script
-        var tag = h.tagName.toLowerCase();
-        var numberText = '';
-        if (tag === 'h2') {
-          h2Count += 1;
-          h3Count = 0;
-          numberText = h2Count + '.\u00A0';
-        } else if (tag === 'h3') {
-          if (h2Count === 0) h2Count = 1;
-          h3Count += 1;
-          numberText = h2Count + '.' + h3Count + '.\u00A0';
-        }
-
-        a.textContent = (numberText ? numberText : '') + h.textContent;
-
-        li.appendChild(a);
-        ul.appendChild(li);
-      });
-
-      tocContainer.appendChild(headingEl);
-      tocContainer.appendChild(ul);
-    });
-  })();
-</script>
-
-    <!-- Mobile hamburger removed: navigation is the same on mobile and desktop -->
-
-    <script>
-      // Auto-number level-2 and level-3 headings inside article/page content
-      (function() {
-        document.addEventListener('DOMContentLoaded', function() {
-          var containers = document.querySelectorAll('.post-content.numbered');
-          if (!containers || !containers.length) return;
-
-          containers.forEach(function(container) {
-            var headings = container.querySelectorAll('h2, h3');
-            var h2Count = 0, h3Count = 0;
-
-            headings.forEach(function(h) {
-              var tag = h.tagName.toLowerCase();
-
-              // Skip if numbering already applied
-              if (h.querySelector('.heading-number')) return;
-
-              if (tag === 'h2') {
-                h2Count += 1;
-                h3Count = 0;
-                var num = h2Count + '.\u00A0';
-                var span = document.createElement('span');
-                span.className = 'heading-number';
-                span.setAttribute('aria-hidden', 'true');
-                span.textContent = num;
-                h.insertBefore(span, h.firstChild);
-              } else if (tag === 'h3') {
-                // If there's no preceding h2, start numbering at 1
-                if (h2Count === 0) h2Count = 1;
-                h3Count += 1;
-                var num3 = h2Count + '.' + h3Count + '.\u00A0';
-                var span3 = document.createElement('span');
-                span3.className = 'heading-number';
-                span3.setAttribute('aria-hidden', 'true');
-                span3.textContent = num3;
-                h.insertBefore(span3, h.firstChild);
-              }
-            });
-          });
-        });
-      })();
-    </script>
-
-
-    <script>
-      // Theme toggle: initialize from localStorage / prefers-color-scheme, toggle on click
-      (function() {
-        var STORAGE_KEY = 'theme';
-
-        function applyTheme(theme) {
-          if (theme === 'dark') document.documentElement.classList.add('dark');
-          else document.documentElement.classList.remove('dark');
-          var btn = document.getElementById('theme-toggle');
-          if (btn) btn.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
-        }
-
-        document.addEventListener('DOMContentLoaded', function() {
-          var btn = document.getElementById('theme-toggle');
-          if (!btn) return;
-
-          // Determine initial theme
-          var saved = null;
-          try { saved = localStorage.getItem(STORAGE_KEY); } catch (e) { saved = null; }
-          if (saved === 'dark' || saved === 'light') {
-            applyTheme(saved);
-          } else {
-            var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-            applyTheme(prefersDark ? 'dark' : 'light');
-          }
-
-          // Toggle handler
-          btn.addEventListener('click', function() {
-            var isDark = document.documentElement.classList.contains('dark');
-            var next = isDark ? 'light' : 'dark';
-            applyTheme(next);
-            try { localStorage.setItem(STORAGE_KEY, next); } catch (e) {}
-          });
-        });
-      })();
-    </script>
-
-    <!-- Copy-to-clipboard for code blocks -->
-    <script src="{{ '/assets/js/copy-code.js' | relative_url }}"></script>
-
-    <!-- TOC highlighting on scroll -->
-    <script src="{{ '/assets/js/scrollspy.js' | relative_url }}"></script>
-
-    <!-- Animations -->
-    <script src="{{ '/assets/js/animations.js' | relative_url }}"></script>
-
-
-
+<script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML"></script>
+<script src="{{ '/assets/js/site-ui.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/i18n.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/copy-code.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/scrollspy.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/animations.js' | relative_url }}"></script>

--- a/_layouts/home_page.html
+++ b/_layouts/home_page.html
@@ -6,13 +6,13 @@ layout: default
 	<div class="post-header-cover">
 		<img src="{{ page.header.overlay_image | default: '/assets/images/header.png' | relative_url }}" alt="{{ page.title | default: site.title }}" loading="lazy" />
 		<div class="post-header-overlay container">
-			<h1 class="post-title">{{ page.title | default: site.title }}</h1>
-			<p class="post-subtitle">{{ page.excerpt | default: site.description }}</p>
+			<h1 class="post-title" data-i18n="home.title">{{ page.title | default: site.title }}</h1>
+			<p class="post-subtitle" data-i18n="home.subtitle">{{ page.excerpt | default: site.description }}</p>
 			{% if page.header.actions and page.header.actions[0] %}
 				{% assign action = page.header.actions[0] %}
-				<a class="hero-button" href="{{ action.url }}">{{ action.label }}</a>
+				<a class="hero-button" href="{{ action.url }}" data-i18n="home.cta">{{ action.label }}</a>
 			{% else %}
-				<a class="hero-button" href="{{ '/about-me/' | relative_url }}">About me</a>
+				<a class="hero-button" href="{{ '/about-me/' | relative_url }}" data-i18n="nav.about">About me</a>
 			{% endif %}
 		</div>
 	</div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -23,7 +23,7 @@ layout: default
       {% assign nav_items = site.data.navigation[nav_key] %}
 
       {% if nav_items %}
-        <h2>Navigation</h2>
+        <h2 data-i18n="layout.navigation">Navigation</h2>
         {% assign current = page.url %}
         <ul class="sidebar-nav">
           {% assign parent_index = 0 %}
@@ -62,7 +62,7 @@ layout: default
     {% assign path = '' %}
     {% if segments.size > 1 %}
       <nav class="breadcrumb">
-        <a href="{{ '/' | relative_url }}">Home</a>
+        <a href="{{ '/' | relative_url }}" data-i18n="layout.home">Home</a>
         {% for segment in segments %}
           {% unless segment == '' or segment contains '.html' %}
             {% assign path = path | append:'/' | append:segment %}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -26,6 +26,9 @@
   --btn-bg: var(--accent);
   --btn-text: #ffffff;
   --btn-bg-hover: #1f4fc6;
+  --about-bg: #ffd8a8;
+  --about-text: #1f2937;
+  --about-bg-hover: #ffb86b;
 }
 
 html {
@@ -2019,6 +2022,136 @@ html.dark .site-nav .nav-link:hover {
   background: rgba(255,255,255,0.04);
 }
 
+.site-header {
+  position: sticky;
+  top: 0;
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  -webkit-backdrop-filter: blur(16px) saturate(140%);
+  backdrop-filter: blur(16px) saturate(140%);
+}
+
+.site-title,
+.site-nav .nav-link {
+  transition: color 0.16s ease, background 0.16s ease, transform 0.16s ease, box-shadow 0.16s ease;
+}
+
+.site-title:hover {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.site-nav .nav-controls {
+  padding: 0.2rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-alt);
+}
+
+.site-nav .nav-link-language {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.language-option {
+  min-width: 1.45rem;
+  color: var(--muted);
+  text-align: center;
+  transition: color 0.16s ease;
+}
+
+.language-option.is-active {
+  color: var(--accent);
+}
+
+.language-divider {
+  color: var(--border);
+  font-weight: 500;
+}
+
+.post-header-cover::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(90deg, rgba(15, 23, 42, 0.76), rgba(15, 23, 42, 0.22) 58%, rgba(15, 23, 42, 0.08)),
+    linear-gradient(180deg, rgba(15, 23, 42, 0.16), rgba(15, 23, 42, 0.42));
+  pointer-events: none;
+}
+
+.post-header-overlay {
+  z-index: 1;
+}
+
+.post-header-overlay .post-title {
+  text-shadow: 0 16px 42px rgba(2, 6, 23, 0.45);
+}
+
+.hero-button,
+.post-navigation a,
+.pagination a,
+.post-meta .tags a {
+  will-change: transform;
+}
+
+.page-sidebar,
+.post-sidebar-left,
+.page-toc,
+.post-toc {
+  scrollbar-gutter: stable;
+}
+
+.sidebar-inner,
+.toc-inner,
+.author-profile {
+  border-radius: 0.65rem;
+}
+
+@media (min-width: 961px) {
+  .sidebar-inner,
+  .toc-inner {
+    padding: 0.9rem 0.95rem;
+    border: 1px solid var(--border);
+    background: color-mix(in srgb, var(--bg-alt) 70%, transparent);
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
+  }
+}
+
+html.dark .site-header {
+  background: color-mix(in srgb, var(--bg) 84%, transparent);
+}
+
+html.dark .site-nav .nav-controls {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+html.dark .sidebar-inner,
+html.dark .toc-inner {
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.24);
+}
+
+@media (max-width: 720px) {
+  .site-nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .site-nav .nav-list {
+    gap: 0.25rem 0.65rem;
+    flex-wrap: wrap;
+  }
+
+  .site-nav .nav-controls {
+    gap: 0.2rem;
+  }
+
+  .site-nav .nav-link {
+    padding: 0.32rem 0.42rem;
+  }
+}
+
 
 /* Copy-to-clipboard button for code blocks */
 .post-content pre,
@@ -2081,11 +2214,30 @@ html.dark .copy-code-button.copied {
 /* Animations */
 .fade-in-on-scroll {
   opacity: 0;
-  transform: translateY(20px);
-  transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+  transform: translateY(18px);
+  transition: opacity 0.55s ease-out, transform 0.55s ease-out;
 }
 
 .fade-in-on-scroll.is-visible {
   opacity: 1;
   transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+
+  .fade-in-on-scroll {
+    opacity: 1;
+    transform: none;
+  }
 }

--- a/assets/js/animations.js
+++ b/assets/js/animations.js
@@ -1,7 +1,22 @@
 (function() {
   document.addEventListener('DOMContentLoaded', function() {
+    const autoTargets = document.querySelectorAll(
+      '.home-content > *, .post-content > *, .page-sidebar, .post-sidebar-left, .page-toc, .post-toc, .author-profile'
+    );
+    autoTargets.forEach((target, index) => {
+      if (!target.classList.contains('fade-in-on-scroll')) {
+        target.classList.add('fade-in-on-scroll');
+        target.style.transitionDelay = `${Math.min(index * 35, 280)}ms`;
+      }
+    });
+
     const targets = document.querySelectorAll('.fade-in-on-scroll');
     if (!targets.length) return;
+
+    if (!('IntersectionObserver' in window)) {
+      targets.forEach(target => target.classList.add('is-visible'));
+      return;
+    }
 
     const observer = new IntersectionObserver((entries, observer) => {
       entries.forEach(entry => {

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -1,0 +1,171 @@
+(function() {
+  var STORAGE_KEY = 'bagelquant.language';
+  var DEFAULT_LANG = 'en';
+  var CHINESE_COUNTRIES = ['CN', 'HK', 'MO', 'TW', 'SG'];
+
+  var dictionary = {
+    en: {
+      'nav.home': 'Home',
+      'nav.quick_start': 'Quick Start',
+      'nav.learn': 'Learn',
+      'nav.research': 'Research',
+      'nav.projects': 'Projects',
+      'nav.docs': 'Docs',
+      'nav.app': 'App',
+      'nav.about': 'About Me',
+      'nav.search_label': 'Search site',
+      'nav.theme_label': 'Toggle dark mode',
+      'nav.lang_label': 'Switch language',
+      'layout.navigation': 'Navigation',
+      'layout.home': 'Home',
+      'toc.title': 'In this article',
+      'home.title': 'BagelQuant',
+      'home.subtitle': 'Quantitative equity research, from first principles to investable portfolios.',
+      'home.cta': 'Start here',
+      'home.what_title': 'What is BagelQuant?',
+      'home.what_body_1': 'BagelQuant is a knowledge base, open-source software ecosystem, and future research platform for quantitative equity portfolio management.',
+      'home.what_body_2': 'The goal is practical: understand how investment ideas become signals, how signals become forecasts, and how forecasts become portfolios that can be tested honestly. The site connects financial theory, statistics, machine learning, optimization, and research engineering around that workflow.',
+      'home.workflow_title': 'The Quant Equity Workflow',
+      'home.workflow_spine': 'Data -> Factor -> Prediction -> Portfolio -> Backtest',
+      'home.workflow_body': 'This simple sequence is the spine of BagelQuant. Each step has its own questions: point-in-time data quality, signal design, predictive modeling, portfolio constraints, turnover, transaction costs, and reproducibility.',
+      'home.start_title': 'Start Here',
+      'home.projects_title': 'Projects and Docs',
+      'home.app_title': 'Future App',
+      'home.about_title': 'About Me'
+    },
+    zh: {
+      'nav.home': '首页',
+      'nav.quick_start': '快速开始',
+      'nav.learn': '学习',
+      'nav.research': '研究',
+      'nav.projects': '项目',
+      'nav.docs': '文档',
+      'nav.app': '应用',
+      'nav.about': '关于我',
+      'nav.search_label': '搜索网站',
+      'nav.theme_label': '切换深色模式',
+      'nav.lang_label': '切换语言',
+      'layout.navigation': '导航',
+      'layout.home': '首页',
+      'toc.title': '本文目录',
+      'home.title': 'BagelQuant',
+      'home.subtitle': '从基础原理到可投资组合的量化股票研究。',
+      'home.cta': '从这里开始',
+      'home.what_title': 'BagelQuant 是什么？',
+      'home.what_body_1': 'BagelQuant 是一个面向量化股票组合管理的知识库、开源软件生态，以及未来的研究平台。',
+      'home.what_body_2': '目标很务实：理解投资想法如何变成信号，信号如何变成预测，预测又如何变成可以被诚实检验的组合。本网站围绕这一流程，把金融理论、统计学、机器学习、优化和研究工程连接起来。',
+      'home.workflow_title': '量化股票研究流程',
+      'home.workflow_spine': '数据 -> 因子 -> 预测 -> 组合 -> 回测',
+      'home.workflow_body': '这条简单的链路是 BagelQuant 的主线。每一步都有自己的关键问题：时点数据质量、信号设计、预测建模、组合约束、换手率、交易成本和可复现性。',
+      'home.start_title': '从这里开始',
+      'home.projects_title': '项目与文档',
+      'home.app_title': '未来应用',
+      'home.about_title': '关于我'
+    }
+  };
+
+  var textMap = {
+    'What is BagelQuant?': 'home.what_title',
+    'The Quant Equity Workflow': 'home.workflow_title',
+    'Data â†’ Factor â†’ Prediction â†’ Portfolio â†’ Backtest': 'home.workflow_spine',
+    'Data → Factor → Prediction → Portfolio → Backtest': 'home.workflow_spine',
+    'Start Here': 'home.start_title',
+    'Projects and Docs': 'home.projects_title',
+    'Future App': 'home.app_title',
+    'About Me': 'home.about_title',
+    'BagelQuant is a knowledge base, open-source software ecosystem, and future research platform for quantitative equity portfolio management.': 'home.what_body_1',
+    'The goal is practical: understand how investment ideas become signals, how signals become forecasts, and how forecasts become portfolios that can be tested honestly. The site connects financial theory, statistics, machine learning, optimization, and research engineering around that workflow.': 'home.what_body_2',
+    'This simple sequence is the spine of BagelQuant. Each step has its own questions: point-in-time data quality, signal design, predictive modeling, portfolio constraints, turnover, transaction costs, and reproducibility.': 'home.workflow_body'
+  };
+
+  function normalizeLang(lang) {
+    return lang === 'zh' || /^zh\b/i.test(lang || '') ? 'zh' : 'en';
+  }
+
+  function getSavedLanguage() {
+    try { return localStorage.getItem(STORAGE_KEY); } catch (e) { return null; }
+  }
+
+  function saveLanguage(lang) {
+    try { localStorage.setItem(STORAGE_KEY, lang); } catch (e) {}
+  }
+
+  function applyLanguage(lang, persist) {
+    lang = normalizeLang(lang);
+    var labels = dictionary[lang] || dictionary[DEFAULT_LANG];
+    document.documentElement.lang = lang === 'zh' ? 'zh-CN' : 'en';
+    document.documentElement.dataset.lang = lang;
+
+    document.querySelectorAll('[data-i18n]').forEach(function(el) {
+      var key = el.getAttribute('data-i18n');
+      if (labels[key]) el.textContent = labels[key];
+    });
+
+    document.querySelectorAll('[data-i18n-aria-label]').forEach(function(el) {
+      var key = el.getAttribute('data-i18n-aria-label');
+      if (labels[key]) el.setAttribute('aria-label', labels[key]);
+    });
+
+    document.querySelectorAll('[data-i18n-title]').forEach(function(el) {
+      var key = el.getAttribute('data-i18n-title');
+      if (labels[key]) el.setAttribute('title', labels[key]);
+    });
+
+    document.querySelectorAll('.home-content h2, .home-content p, .home-content strong').forEach(function(el) {
+      var key = el.getAttribute('data-i18n-detected') || textMap[(el.textContent || '').trim()];
+      if (key) el.setAttribute('data-i18n-detected', key);
+      if (key && labels[key]) el.textContent = labels[key];
+    });
+
+    var toggle = document.getElementById('language-toggle');
+    if (toggle) {
+      toggle.setAttribute('aria-pressed', lang === 'zh' ? 'true' : 'false');
+      toggle.querySelectorAll('[data-lang-option]').forEach(function(option) {
+        option.classList.toggle('is-active', option.getAttribute('data-lang-option') === lang);
+      });
+    }
+
+    window.dispatchEvent(new CustomEvent('bagelquant:languagechange', { detail: { language: lang } }));
+    if (persist) saveLanguage(lang);
+  }
+
+  function guessLanguageFromBrowser() {
+    var langs = navigator.languages && navigator.languages.length ? navigator.languages : [navigator.language];
+    return langs.some(function(lang) { return /^zh\b/i.test(lang || ''); }) ? 'zh' : DEFAULT_LANG;
+  }
+
+  function guessLanguageFromIp() {
+    return fetch('https://ipapi.co/json/', { cache: 'no-store' })
+      .then(function(response) {
+        if (!response.ok) throw new Error('Locale lookup failed');
+        return response.json();
+      })
+      .then(function(data) {
+        return CHINESE_COUNTRIES.indexOf((data && data.country_code || '').toUpperCase()) >= 0 ? 'zh' : DEFAULT_LANG;
+      });
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    var saved = getSavedLanguage();
+    if (saved) {
+      applyLanguage(saved, false);
+    } else {
+      applyLanguage(guessLanguageFromBrowser(), false);
+      guessLanguageFromIp().then(function(lang) {
+        if (!getSavedLanguage()) applyLanguage(lang, false);
+      }).catch(function() {});
+    }
+
+    var toggle = document.getElementById('language-toggle');
+    if (toggle) {
+      toggle.addEventListener('click', function() {
+        var current = document.documentElement.dataset.lang || DEFAULT_LANG;
+        applyLanguage(current === 'zh' ? 'en' : 'zh', true);
+      });
+    }
+  });
+
+  window.BagelQuantI18n = {
+    applyLanguage: applyLanguage
+  };
+})();

--- a/assets/js/site-ui.js
+++ b/assets/js/site-ui.js
@@ -1,0 +1,168 @@
+(function() {
+  function setupSidebarToggle() {
+    var mq = window.matchMedia('(max-width: 960px)');
+    var initialized = false;
+
+    function setupToggle() {
+      if (!mq.matches || initialized) return;
+      initialized = true;
+
+      var sidebar = document.querySelector('.page-sidebar') || document.querySelector('.post-sidebar-left');
+      if (!sidebar) return;
+
+      var layout = document.querySelector('.layout-three-column');
+      if (!layout || layout.parentNode.querySelector('.sidebar-toggle')) return;
+
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'sidebar-toggle';
+      btn.setAttribute('aria-label', 'Toggle navigation');
+      btn.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">'
+        + '<path d="M3 6h18" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>'
+        + '<path d="M3 12h18" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>'
+        + '<path d="M3 18h18" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>'
+        + '</svg>';
+      btn.addEventListener('click', function() {
+        sidebar.classList.toggle('is-open');
+      });
+
+      layout.parentNode.insertBefore(btn, layout);
+    }
+
+    setupToggle();
+    mq.addEventListener('change', function(e) {
+      if (e.matches) setupToggle();
+    });
+  }
+
+  function setupToc() {
+    var content = document.querySelector('.post-content.numbered');
+    if (!content) return;
+
+    var pageOptions = window.BagelQuantPage || {};
+    if (pageOptions.toc === false) return;
+
+    var headings = content.querySelectorAll('h2, h3');
+    if (!headings.length) return;
+
+    var tocContainer = document.querySelector('.post-toc .toc-inner') ||
+                       document.querySelector('.page-toc .toc-inner');
+    if (!tocContainer) return;
+
+    tocContainer.innerHTML = '';
+
+    var headingEl = document.createElement('h2');
+    headingEl.textContent = 'In this article';
+    headingEl.setAttribute('data-i18n', 'toc.title');
+
+    var ul = document.createElement('ul');
+    var h2Count = 0;
+    var h3Count = 0;
+
+    headings.forEach(function(h) {
+      if (!h.id) {
+        h.id = h.textContent.trim().toLowerCase()
+          .replace(/[^\w\- ]+/g, '')
+          .replace(/\s+/g, '-');
+      }
+
+      var li = document.createElement('li');
+      li.className = 'toc-level-' + h.tagName.toLowerCase();
+
+      var a = document.createElement('a');
+      a.href = '#' + h.id;
+
+      var tag = h.tagName.toLowerCase();
+      var numberText = '';
+      if (tag === 'h2') {
+        h2Count += 1;
+        h3Count = 0;
+        numberText = h2Count + '.\u00A0';
+      } else if (tag === 'h3') {
+        if (h2Count === 0) h2Count = 1;
+        h3Count += 1;
+        numberText = h2Count + '.' + h3Count + '.\u00A0';
+      }
+
+      a.textContent = (numberText ? numberText : '') + h.textContent;
+      li.appendChild(a);
+      ul.appendChild(li);
+    });
+
+    tocContainer.appendChild(headingEl);
+    tocContainer.appendChild(ul);
+  }
+
+  function setupHeadingNumbers() {
+    var containers = document.querySelectorAll('.post-content.numbered');
+    if (!containers.length) return;
+
+    containers.forEach(function(container) {
+      var headings = container.querySelectorAll('h2, h3');
+      var h2Count = 0;
+      var h3Count = 0;
+
+      headings.forEach(function(h) {
+        var tag = h.tagName.toLowerCase();
+        if (h.querySelector('.heading-number')) return;
+
+        if (tag === 'h2') {
+          h2Count += 1;
+          h3Count = 0;
+          addNumber(h, h2Count + '.\u00A0');
+        } else if (tag === 'h3') {
+          if (h2Count === 0) h2Count = 1;
+          h3Count += 1;
+          addNumber(h, h2Count + '.' + h3Count + '.\u00A0');
+        }
+      });
+    });
+  }
+
+  function addNumber(heading, text) {
+    var span = document.createElement('span');
+    span.className = 'heading-number';
+    span.setAttribute('aria-hidden', 'true');
+    span.textContent = text;
+    heading.insertBefore(span, heading.firstChild);
+  }
+
+  function setupThemeToggle() {
+    var STORAGE_KEY = 'theme';
+
+    function applyTheme(theme) {
+      if (theme === 'dark') document.documentElement.classList.add('dark');
+      else document.documentElement.classList.remove('dark');
+
+      var btn = document.getElementById('theme-toggle');
+      if (btn) btn.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+    }
+
+    var btn = document.getElementById('theme-toggle');
+    if (!btn) return;
+
+    var saved = null;
+    try { saved = localStorage.getItem(STORAGE_KEY); } catch (e) { saved = null; }
+
+    if (saved === 'dark' || saved === 'light') {
+      applyTheme(saved);
+    } else {
+      var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      applyTheme(prefersDark ? 'dark' : 'light');
+    }
+
+    btn.addEventListener('click', function() {
+      var isDark = document.documentElement.classList.contains('dark');
+      var next = isDark ? 'light' : 'dark';
+      applyTheme(next);
+      try { localStorage.setItem(STORAGE_KEY, next); } catch (e) {}
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    setupSidebarToggle();
+    setupHeadingNumbers();
+    setupToc();
+    setupThemeToggle();
+  });
+})();


### PR DESCRIPTION
## What
- Add a site-wide English/Chinese language switch for BagelQuant website chrome and homepage copy.
- Add IP-based initial locale detection with browser-language fallback and persisted manual preference.
- Refresh the website visuals with a cleaner sticky header, grouped controls, improved hero overlays, polished sidebars, and automatic reveal animations.
- Organize shared client behavior by moving inline layout scripts into dedicated JavaScript assets.

## Why
- Visitors should be able to read core website entry points in English or Chinese without changing URLs.
- Locale should feel automatic for Chinese-region visitors while still respecting explicit user choice.
- The website should feel cleaner and more modern, with shared behavior easier to maintain.

## How
- Added `assets/js/i18n.js` for translation dictionaries, language switching, persistence, and IP/browser locale detection.
- Added `assets/js/site-ui.js` for sidebar toggles, TOC generation, heading numbering, and theme toggling.
- Updated navigation/layout markup with i18n keys and a header language toggle.
- Replaced the large inline script include with focused asset imports.
- Extended `assets/css/main.css` and `assets/js/animations.js` for the refreshed UI and reveal behavior.

## Testing
- Reviewed the full diff for layout, script, and style changes.
- Pushed branch successfully to origin.
- Local Jekyll build was not run because Ruby/Bundler is not installed in this shell.
- Shell Node syntax checks were not available earlier because node.exe was blocked by the Windows sandbox in that environment.

## Notes
- Branch follows the documented convention: `feature/website-i18n-refresh`.
- Commit follows Conventional Commit style: `feat: refresh website i18n and ui`.
- The previous non-convention branch `website-i18n-refresh` was pushed before this convention pass; this PR uses the convention-aligned branch.
